### PR TITLE
Add makefile for easy releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+GIT_VERSION = $(shell git describe --tags --dirty)
+VERSION ?= $(GIT_VERSION)
+
+VERSION_PACKAGE := github.com/dispatchframework/funky/pkg/version
+
+GO_LDFLAGS := -X $(VERSION_PACKAGE).version=$(VERSION)
+GO_LDFLAGS += -X $(VERSION_PACKAGE).buildDate=$(shell date +'%Y-%m-%dT%H:%M:%SZ')
+GO_LDFLAGS += -X $(VERSION_PACKAGE).commit=$(shell git rev-parse HEAD)
+
+
+.PHONY: all
+all: linux
+
+.PHONY: test
+test: ## run tests
+	@echo running tests...
+	$(GO) test -v $(shell go list -v ./... | grep -v /vendor/ | grep -v integration )
+
+.PHONY: linux
+linux:
+	GOOS=linux go build -ldflags "$(GO_LDFLAGS)" -o funky main.go
+
+.PHONY: release
+release: linux
+	tar -czf funky$(VERSION).linux-amd64.tgz funky

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,34 @@
+///////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+///////////////////////////////////////////////////////////////////////
+
+package version
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/vmware/dispatch/pkg/api/v1"
+)
+
+// Filled by -ldflags passed to `go build`
+var (
+	version   string
+	commit    string
+	buildDate string
+)
+
+// NO TESTS
+
+// Get returns information about the version/build
+func Get() *v1.Version {
+	return &v1.Version{
+		Version:   version,
+		Commit:    commit,
+		BuildDate: buildDate,
+		GoVersion: runtime.Version(),
+		Compiler:  runtime.Compiler,
+		Platform:  fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}


### PR DESCRIPTION
To create a release, first create the release/tag in github
then simply run `make release`.  The artifact may then be uploaded
to the release.