### PR TITLE
Transform GET/OPTIONS to POST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+*.pyc
 
 # Test binary, build with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 GIT_VERSION = $(shell git describe --tags --dirty)
 VERSION ?= $(GIT_VERSION)
 
+SHELL := /bin/bash
+GO ?= go
+
 VERSION_PACKAGE := github.com/dispatchframework/funky/pkg/version
 
 GO_LDFLAGS := -X $(VERSION_PACKAGE).version=$(VERSION)

--- a/README.md
+++ b/README.md
@@ -7,3 +7,20 @@ Funky requires two environment variables:
   * SERVER_CMD - the command to run to start a function server e.g. `python3 main.py hello.handle`
 
 Any request to the function server will try to invoke the function on any free server. The request will block if no server if idle and able to process the request.
+
+## Development
+
+Doing local development is easy.
+
+1. Check out/clone the python3-base-image:
+    ```
+    cd ..
+    git clone git@github.com:dispatchframework/python3-base-image.git
+    cd -
+    ```
+2. Run funky locally (pointing to the example function):
+    ```
+    PORT=8080 TIMEOUT=30 SERVERS=1 SERVER_CMD="python3 ../python3-base-image/function-server/main.py example.handler.dummy" go run main.go
+    ```
+
+TODO: Funky needs logging!

--- a/example/handler.py
+++ b/example/handler.py
@@ -1,0 +1,4 @@
+def dummy(context, payload):
+    print("hello dummy")
+    payload["function"] = "dummy"
+    return payload

--- a/pkg/funky/http_message_converter.go
+++ b/pkg/funky/http_message_converter.go
@@ -11,9 +11,19 @@ import (
 	"encoding/json"
 	"net/http"
 	"reflect"
+	"strings"
 
 	"github.com/ghodss/yaml"
 )
+
+func getTypeFromFragment(mediaType string) string {
+	fragments := strings.Split(mediaType, "+")
+	if len(fragments) == 2 {
+		// Use the identifier as the content type
+		mediaType = fragments[1]
+	}
+	return mediaType
+}
 
 // HTTPReaderWriter Describes an interface that can read arbitary objects from an http request and write arbitary objects to an http response
 type HTTPReaderWriter interface {
@@ -72,7 +82,7 @@ type JSONHTTPMessageConverter struct {
 
 // NewJSONHTTPMessageConverter constructs a JSONHTTPMessageConverter, sets supported media type to "application/json"
 func NewJSONHTTPMessageConverter() *JSONHTTPMessageConverter {
-	supportedMediaTypes := []string{"application/json"}
+	supportedMediaTypes := []string{"*/*", "application/json", "json"}
 	supportedMediaTypesMap := map[string]bool{}
 	for _, v := range supportedMediaTypes {
 		supportedMediaTypesMap[v] = true
@@ -85,6 +95,7 @@ func NewJSONHTTPMessageConverter() *JSONHTTPMessageConverter {
 
 // CanRead returns true if this converter can convert input described in the given media type into the given type, false otherwise
 func (j *JSONHTTPMessageConverter) CanRead(t reflect.Type, mediaType string) bool {
+	mediaType = getTypeFromFragment(mediaType)
 	return j.supportedMediaTypesMap[mediaType]
 }
 
@@ -115,7 +126,7 @@ type YAMLHTTPMessageConverter struct {
 
 // NewYAMLHTTPMessageConverter constructs a YAMLHTTPMessageConverter, sets supported media type to "application/yaml"
 func NewYAMLHTTPMessageConverter() *YAMLHTTPMessageConverter {
-	supportedMediaTypes := []string{"application/yaml"}
+	supportedMediaTypes := []string{"*/*", "application/yaml", "yaml"}
 	supportedMediaTypesMap := map[string]bool{}
 	for _, v := range supportedMediaTypes {
 		supportedMediaTypesMap[v] = true
@@ -128,6 +139,7 @@ func NewYAMLHTTPMessageConverter() *YAMLHTTPMessageConverter {
 
 // CanRead returns true if this converter can convert input described in the given media type into the given type, false otherwise
 func (y *YAMLHTTPMessageConverter) CanRead(t reflect.Type, mediaType string) bool {
+	mediaType = getTypeFromFragment(mediaType)
 	return y.supportedMediaTypesMap[mediaType]
 }
 
@@ -164,7 +176,7 @@ type Base64HTTPMessageConverter struct {
 
 // NewBase64HTTPMessageConverter constructs a Base64HTTPMessageConverter, sets supported media type to "application/base64"
 func NewBase64HTTPMessageConverter() *Base64HTTPMessageConverter {
-	supportedMediaTypes := []string{"application/base64"}
+	supportedMediaTypes := []string{"*/*", "application/base64"}
 	supportedMediaTypesMap := map[string]bool{}
 	for _, v := range supportedMediaTypes {
 		supportedMediaTypesMap[v] = true
@@ -221,7 +233,7 @@ type PlainTextHTTPMessageConverter struct {
 
 // NewPlainTextHTTPMessageConverter constructs a PlainTextHTTPMessageConverter, sets supported media type to "text/plain"
 func NewPlainTextHTTPMessageConverter() *PlainTextHTTPMessageConverter {
-	supportedMediaTypes := []string{"text/plain"}
+	supportedMediaTypes := []string{"*/*", "text/plain"}
 	supportedMediaTypesMap := map[string]bool{}
 	for _, v := range supportedMediaTypes {
 		supportedMediaTypesMap[v] = true


### PR DESCRIPTION
* functions expect POST requests so non-POST requests must be
  transformed
* handle empty payloads better
* allow more mime types, specifically */* and application/something+json
	- should probably differenciate between content type and accept

Signed-off-by: Berndt Jung <bjung@vmware.com>